### PR TITLE
Fix the docs

### DIFF
--- a/_documentation/getting-started.md
+++ b/_documentation/getting-started.md
@@ -14,7 +14,7 @@ It should be able to run the contents of a particular branch
 and report its results using a GitHub Status notification
 (the little <abbr style="color:orange" title="The build is in progress">&bull;</abbr>, <abbr style="color:green" title="Build succeeded">&#10003;</abbr>, or <abbr style="color:red" title="Build failed">&times;</abbr> next to a commit in the commits list).Newer CI systems, like Travis and AppVeyor, will do this by default. Jenkins and BuildBot have plugins for it.
 
-Your CI system should build the "staging" and "trying" branches, but should not build a branch called "staging.tmp".
+Your CI system should build the "staging" and "trying" branches, but should not build the "staging.tmp" and "trying.tmp" branches.
 If your CI system is misconfigured to do this, bors should notify you. For example, add this to your .travis.yml or appveyor.yml file:
 
 ```yaml


### PR DESCRIPTION
Not sure this correct, but I get a bunch of notifications about failed trying.tmp with messages like

>fatal: Remote branch trying.tmp not found in upstream origin

so, looks like it also should be excluded from CI?