### PR TITLE
Update syntax table's descriptions

### DIFF
--- a/_documentation/reference.md
+++ b/_documentation/reference.md
@@ -12,16 +12,16 @@ description: All of the commands and configuration options supported by bors-ng
 
 | Syntax | Description |
 |--------|-------------|
-| bors r+ | Run the test suite, and push to master if it passes. Short for "reviewed: looks good."
+| bors r+ | Run the test suite and push to master if it passes. Short for "reviewed: looks good."
 | bors r=[list] | Same as r+, but the "reviewer" in the commit log will be recorded as the user(s) given as the argument.
 | bors r- | Cancel an r+ or r=.
-| bors try | Run the test suite, without pushing to master.
+| bors try | Run the test suite without pushing to master.
 | bors delegate+ | Allow the pull request author to r+ their changes.
 | bors delegate=[list] | Allow the listed users to r+ this pull request's changes.
-| bors ping | Will respond if bors is set up.
+| bors ping | Check if bors is up. If it is, it will comment with _pong_.
 | bors retry | Run the previous command a second time.
-| bors p=[priority] | Set the priority of the current pull request
-| bors r+ p=[priority] | Set the priority, run the test suite, and push to master (shorthand for doing p= and r+ one after the other)
+| bors p=[priority] | Set the priority of the current pull request.
+| bors r+ p=[priority] | Set the priority, run the test suite, and push to master (shorthand for doing p= and r+ one after the other).
 
 The keyword (`bors`) may be separated with a space or a colon. That is, `bors try` and `bors: try` are the same thing.
 Also, the command will be recognized if, and only if, the word "bors" is at the beginning of a line.


### PR DESCRIPTION
I had copied some of this into my own doc, and a reviewer pointed
out some grammar inconsistencies. Might as well fix them
upstream.