### PR TITLE
Update the documentation with the `bors merge` alias

### DIFF
--- a/_documentation/getting-started.md
+++ b/_documentation/getting-started.md
@@ -59,6 +59,10 @@ leave a comment like this on the pull request:
 
 > bors r+
 
+Equivalently, you can comment the following:
+
+> bors merge
+
 The pull request,
 as well as any other pull requests that are reviewed around the same time,
 will be merged into a branch called "staging".

--- a/_documentation/reference.md
+++ b/_documentation/reference.md
@@ -14,8 +14,11 @@ description: All of the commands and configuration options supported by bors-ng
 | Syntax | Description |
 |--------|-------------|
 | bors r+ | Run the test suite and push to master if it passes. Short for "reviewed: looks good."
+| bors merge | Equivalent to `bors r+`.
 | bors r=[list] | Same as r+, but the "reviewer" in the commit log will be recorded as the user(s) given as the argument.
-| bors r- | Cancel an r+ or r=.
+| bors merge=[list] | Equivalent to `bors r=[list]`
+| bors r- | Cancel an r+, r=, merge, or merge=
+| bors merge- | Equivalent to `bors r-`
 | bors try | Run the test suite without pushing to master.
 | bors try- | Cancel a try
 | bors delegate+ <br> bors d+ | Allow the pull request author to r+ their changes.
@@ -24,6 +27,7 @@ description: All of the commands and configuration options supported by bors-ng
 | bors retry | Run the previous command a second time.
 | bors p=[priority] | Set the priority of the current pull request. Pull requests with different priority are never batched together. The pull request with the bigger priority number goes first.
 | bors r+ p=[priority] | Set the priority, run the test suite, and push to master (shorthand for doing p= and r+ one after the other).
+| bors merge p=[priority] | Equivalent to `bors r+ p=[priority]`
 
 The keyword (`bors`) may be separated with a space or a colon. That is, `bors try` and `bors: try` are the same thing.
 Also, the command will be recognized if, and only if, the word "bors" is at the beginning of a line.
@@ -42,33 +46,43 @@ And if you want to copy the above table into a markdown comment, make sure that 
 
     Syntax | Description
     -------|------------
-    bors r+ | Run the test suite
-    bors r=[list] | Same as r+, but the "reviewer" will come from the argument
-    bors r- | Cancel an r+ or r=
-    bors try | Run the test suite without pushing
+    bors r+ | Run the test suite and push to master if it passes. Short for "reviewed: looks good."
+    bors merge | Equivalent to `bors r+`.
+    bors r=[list] | Same as r+, but the "reviewer" in the commit log will be recorded as the user(s) given as the argument.
+    bors merge=[list] | Equivalent to `bors r=[list]`
+    bors r- | Cancel an r+, r=, merge, or merge=
+    bors merge- | Equivalent to `bors r-`
+    bors try | Run the test suite without pushing to master.
     bors try- | Cancel a try
-    bors delegate+ | Allow the pull request author to r+
-    bors delegate=[list] | Allow the listed users to r+
-    bors ping | Will respond if bors is set up
+    bors delegate+ <br> bors d+ | Allow the pull request author to r+ their changes.
+    bors delegate=[list] <br> bors d=[list] | Allow the listed users to r+ this pull request's changes.
+    bors ping | Check if bors is up. If it is, it will comment with _pong_.
     bors retry | Run the previous command a second time.
-    bors p=[priority] | Set the priority
-    bors r+ p=[priority] | Shorthand for `bors p=[priority]` followed by `bors r+`
+    bors p=[priority] | Set the priority of the current pull request. Pull requests with different priority are never batched together. The pull request with the bigger priority number goes first.
+    bors r+ p=[priority] | Set the priority, run the test suite, and push to master (shorthand for doing p= and r+ one after the other).
+    bors merge p=[priority] | Equivalent to `bors r+ p=[priority]`
 
 On the other hand, bors will ignore this table if it's given [like this (with the optional pipes at the beginning of every line)](https://github.com/notriddle/test_repo/pull/118#issuecomment-334333878):
 
+
+
     | Syntax | Description
     |--------|------------
-    | bors r+ | Run the test suite
-    | bors r=[list] | Same as r+, but the "reviewer" will come from the argument
-    | bors r- | Cancel an r+ or r=
-    | bors try | Run the test suite without pushing
+    | bors r+ | Run the test suite and push to master if it passes. Short for "reviewed: looks good."
+    | bors merge | Equivalent to `bors r+`.
+    | bors r=[list] | Same as r+, but the "reviewer" in the commit log will be recorded as the user(s) given as the argument.
+    | bors merge=[list] | Equivalent to `bors r=[list]`
+    | bors r- | Cancel an r+, r=, merge, or merge=
+    | bors merge- | Equivalent to `bors r-`
+    | bors try | Run the test suite without pushing to master.
     | bors try- | Cancel a try
-    | bors delegate+ | Allow the pull request author to r+
-    | bors delegate=[list] | Allow the listed users to r+
-    | bors ping | Will respond if bors is set up
+    | bors delegate+ <br> bors d+ | Allow the pull request author to r+ their changes.
+    | bors delegate=[list] <br> bors d=[list] | Allow the listed users to r+ this pull request's changes.
+    | bors ping | Check if bors is up. If it is, it will comment with _pong_.
     | bors retry | Run the previous command a second time.
-    | bors p=[priority] | Set the priority
-    | bors r+ p=[priority] | Shorthand for `bors p=[priority]` followed by `bors r+`
+    | bors p=[priority] | Set the priority of the current pull request. Pull requests with different priority are never batched together. The pull request with the bigger priority number goes first.
+    | bors r+ p=[priority] | Set the priority, run the test suite, and push to master (shorthand for doing p= and r+ one after the other).
+    | bors merge p=[priority] | Equivalent to `bors r+ p=[priority]`
 
 ## Configuration (bors.toml)
 


### PR DESCRIPTION
Once https://forum.bors.tech/t/allow-merge-as-an-alias-for-r/376 is accepted and https://github.com/bors-ng/bors-ng/pull/746 is merged, this pull request will add the `bors merge` alias to the Bors documentation