### PR TITLE
feat: add CircleCI to getting started docs.

### DIFF
--- a/_documentation/getting-started.md
+++ b/_documentation/getting-started.md
@@ -61,9 +61,7 @@ For example, this will work for a repo with Travis CI and AppVeyor:
 ```toml
 status = [
   "continuous-integration/travis-ci/push",
-  "continuous-integration/appveyor/branch",
-  "ci/circleci: some-job", #CircleCI using GitHub Status
-  "workflow-name" #CircleCI using new GitHub Checks
+  "continuous-integration/appveyor/branch"
 ]
 # Uncomment this to use a two hour timeout.
 # The default is one hour.

--- a/_documentation/getting-started.md
+++ b/_documentation/getting-started.md
@@ -28,7 +28,7 @@ branches:
     #- master
 ```
 
-Or, if using CircleCI filter the :
+Or, if using CircleCI filter the various jobs.
 ```yaml
 workflows:
   build-deploy:


### PR DESCRIPTION
I struggled getting bors running on Circle as there were some notable differences to travis/appveyer examples covered.  This PR adds the required bors.toml to support CIrcleCI checks, and branch filtering examples.


