### PR TITLE
Clarify recent temp branch rename

### DIFF
--- a/_documentation/getting-started.md
+++ b/_documentation/getting-started.md
@@ -14,8 +14,7 @@ It should be able to run the contents of a particular branch
 and report its results using a GitHub Status notification
 (the little <abbr style="color:orange" title="The build is in progress">&bull;</abbr>, <abbr style="color:green" title="Build succeeded">&#10003;</abbr>, or <abbr style="color:red" title="Build failed">&times;</abbr> next to a commit in the commits list). Newer CI systems, like Travis, AppVeyor, and CircleCI will do this by default. Jenkins and BuildBot have plugins for it.
 
-Your CI system should build the "staging" and "trying" branches, but should not build the "staging.tmp" and "trying.tmp" branches.
-If your CI system is misconfigured to do this, bors should notify you. For example, add this to your .travis.yml or appveyor.yml file:
+Your CI system should build the "staging" and "trying" branches, but should not build the "staging.tmp" and "trying.tmp" branches. As of recently, it should also not build the "staging-squash-merge.tmp" branch. A recommendation is to configure your CI system to not build on branches that match a pattern such as `*.tmp`. If your CI system is misconfigured to do this, bors should notify you. For example, add this to your .travis.yml or appveyor.yml file:
 
 ```yaml
 branches:


### PR DESCRIPTION
Hey folks, first of all thanks for this project, it's been really useful. Here at Nubank we've been using it to greatly improve the contribution experience and build times for a few mono-repos we have, for Data Engineering and for the mobile platform team.

My ex-colleague @gmendonca contributed back a bit to bors in the past, so I wanted to follow his lead and improve this detail in the documentation.

Earlier today I dealt with an issue that was rather tricky to understand at first sight, and I missed a bit more clarity on the docs related to the change in https://github.com/bors-ng/bors-ng/pull/933, which introduced a `staging-squash-merge.tmp` branch, so this PR is just to add a piece of text explaining that the CI system should also ignore this branch.

I welcome any feedback about the text, especially the `recent` part, I was not sure if I could reference a commit or a version number of sorts, what do you think?

Thanks again!