### PR TITLE
Add commit_title to reference

### DIFF
--- a/_documentation/reference.md
+++ b/_documentation/reference.md
@@ -102,6 +102,7 @@ On the other hand, bors will ignore this table if it's given [like this (with th
 | use_codeowners         | boolean     | If turned on, `CODEOWNERS` file will be parsed. [See GitHub's docs](https://help.github.com/en/articles/about-code-owners) for more info. |
 | use_squash_merge       | boolean     | If turned on, commits will be Squashed before merging and the Pull Request will be Closed with `[Merged by Bors] - ` addition to the tile. [See Github's docs](https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits) for more info. |
 | update_base_for_deletes | boolean    | If turned on, and if `delete_merged_branches` is also turned on, then when a pull request is merged and its base branch is about to be deleted, any other pull requests made against the base branch will be fixed up. |
+| commit_title           | string      | The title of the merge commit message. Can be templated with `${PR_REFS}` to refer to the merged PR(s). Default is: `Merge ${PR_REFS}`
 
 Note that underscores (`_`) and hyphens (`-`) are interchangable in configuration option names. That is, `pr_status` and `pr-status` are the same thing.
 


### PR DESCRIPTION
This PR adds a configuration entry to the reference guide for the `commit_title`. 
The `commit_title` configuration was added with https://github.com/bors-ng/bors-ng/pull/1040.
